### PR TITLE
feat(dart): create Dart feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       matrix:
         features:
-          # - color
-          # - hello
+          - dart
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -34,8 +33,7 @@ jobs:
     strategy:
       matrix:
         features:
-          # - color
-          # - hello
+          - dart
     steps:
       - uses: actions/checkout@v3
 

--- a/src/dart/NOTES.md
+++ b/src/dart/NOTES.md
@@ -14,5 +14,12 @@ This feature installs the Dart SDK using the official installer script. You can
 choose to pin a specific version with the `version` input. You might also want
 to check out [Flutter] if you're interested in Dart.
 
+🆘 If you're having trouble with this feature, [open a Discussion] or [open an
+Issue]! We'd be happy to fix bugs! 🐛
+
+<!-- prettier-ignore-start -->
 [Dart programming language | Dart]: https://dart.dev/
 [Flutter]: https://flutter.dev/
+[open a Discussion]: https://github.com/devcontainers-community/features/discussions/new?category=q-a
+[open an Issue]: https://github.com/devcontainers-community/features/issues/new
+<!-- prettier-ignore-end -->

--- a/src/dart/NOTES.md
+++ b/src/dart/NOTES.md
@@ -1,0 +1,18 @@
+<!-- markdownlint-disable MD041 MD033 -->
+
+<div align="center">
+
+[![Dart website](https://thum.io/get/width/800/crop/600/noanimate/https://dart.dev/)](https://dart.dev/)
+
+</div>
+
+> Dart is a client-optimized language for fast apps on any platform
+
+&mdash; [Dart programming language | Dart]
+
+This feature installs the Dart SDK using the official installer script. You can
+choose to pin a specific version with the `version` input. You might also want
+to check out [Flutter] if you're interested in Dart.
+
+[Dart programming language | Dart]: https://dart.dev/
+[Flutter]: https://flutter.dev/

--- a/src/dart/_common.sh
+++ b/src/dart/_common.sh
@@ -1,0 +1,24 @@
+updaterc() {
+    echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc..."
+    if [[ "$(cat /etc/bash.bashrc)" != *"$1"* ]]; then
+        echo -e "$1" >> /etc/bash.bashrc
+    fi
+    if [ -f "/etc/zsh/zshrc" ] && [[ "$(cat /etc/zsh/zshrc)" != *"$1"* ]]; then
+        echo -e "$1" >> /etc/zsh/zshrc
+    fi
+}
+
+apt_get_update() {
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        apt_get_update
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}

--- a/src/dart/devcontainer-feature.json
+++ b/src/dart/devcontainer-feature.json
@@ -9,5 +9,10 @@
       "type": "string",
       "default": "latest"
     }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["dart-code.dart-code"]
+    }
   }
 }

--- a/src/dart/devcontainer-feature.json
+++ b/src/dart/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+  "id": "dart",
+  "name": "Dart",
+  "description": "Installs the Dart SDK",
+  "version": "1.0.0",
+  "options": {
+    "version": {
+      "description": "Dart version",
+      "type": "string",
+      "default": "latest"
+    }
+  }
+}

--- a/src/dart/install.sh
+++ b/src/dart/install.sh
@@ -2,11 +2,9 @@
 set -e
 source _common.sh
 
-check_packages wget gpg
+check_packages wget gpg apt-transport-https ca-certificates
 
 # https://dart.dev/get-dart
-apt-get update
-apt-get install apt-transport-https
 wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list
 

--- a/src/dart/install.sh
+++ b/src/dart/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+source _common.sh
+
+# https://dart.dev/get-dart
+# "Perform the following one-time setup:"
+sudo apt-get update
+sudo apt-get install apt-transport-https
+wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
+echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
+# "Then install the Dart SDK:"
+sudo apt-get update
+sudo apt-get install dart
+
+# Now that we have Dart installed to /usr/lib/dart/bin, we need to expose that
+# to future shell sessions via $PATH.
+updaterc 'export PATH="$PATH:/usr/lib/dart/bin"'

--- a/src/dart/install.sh
+++ b/src/dart/install.sh
@@ -2,7 +2,7 @@
 set -e
 source _common.sh
 
-check_packages wget
+check_packages wget gpg
 
 # https://dart.dev/get-dart
 apt-get update

--- a/src/dart/install.sh
+++ b/src/dart/install.sh
@@ -5,17 +5,16 @@ source _common.sh
 # TODO: Do we need to "check_packages" here?
 
 # https://dart.dev/get-dart
-# "Perform the following one-time setup:"
-sudo apt-get update
-sudo apt-get install apt-transport-https
+apt-get update
+apt-get install apt-transport-https
 wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
-# "Then install the Dart SDK:"
+
 sudo apt-get update
 if [[ -z $VERSION || $VERSION == latest ]]; then
-  sudo apt-get install dart
+  apt-get install dart
 else
-  sudo apt-get install "dart=$VERSION"
+  apt-get install "dart=$VERSION"
 fi
 
 # Now that we have Dart installed to /usr/lib/dart/bin, we need to expose that

--- a/src/dart/install.sh
+++ b/src/dart/install.sh
@@ -2,6 +2,8 @@
 set -e
 source _common.sh
 
+# TODO: Do we need to "check_packages" here?
+
 # https://dart.dev/get-dart
 # "Perform the following one-time setup:"
 sudo apt-get update

--- a/src/dart/install.sh
+++ b/src/dart/install.sh
@@ -10,7 +10,11 @@ wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dea
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
 # "Then install the Dart SDK:"
 sudo apt-get update
-sudo apt-get install dart
+if [[ -z $VERSION || $VERSION == latest ]]; then
+  sudo apt-get install dart
+else
+  sudo apt-get install "dart=$VERSION"
+fi
 
 # Now that we have Dart installed to /usr/lib/dart/bin, we need to expose that
 # to future shell sessions via $PATH.

--- a/src/dart/install.sh
+++ b/src/dart/install.sh
@@ -7,10 +7,10 @@ check_packages wget
 # https://dart.dev/get-dart
 apt-get update
 apt-get install apt-transport-https
-wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
-echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
+wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg
+echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list
 
-sudo apt-get update
+apt-get update
 if [[ -z $VERSION || $VERSION == latest ]]; then
   apt-get install dart
 else

--- a/src/dart/install.sh
+++ b/src/dart/install.sh
@@ -2,7 +2,7 @@
 set -e
 source _common.sh
 
-# TODO: Do we need to "check_packages" here?
+check_packages wget
 
 # https://dart.dev/get-dart
 apt-get update

--- a/test/dart/test.sh
+++ b/test/dart/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+source dev-container-features-test-lib
+
+check 'dart' dart --version
+
+reportResults


### PR DESCRIPTION
There is no "Dart" feature on https://containers.dev/features yet. I would like to add this feature so that the https://github.com/devcontainers-community/templates/pull/31 Dart template can use this Dart feature without needing to install it in a Dockerfile.

This PR would...
- [x] Add a Dart installer
- [x] Use `_common.sh` until https://github.com/devcontainers/spec/pull/209 is implemented in tooling?
- [x] Add a `version` option to choose the version of the Dart SDK
- [ ] Install other Dart extensions/libs
- [x] Add a NOTES.md that references the tool that is being installed
- [x] Include links to getting help in NOTES.md

I am not familiar with the Dart ecosystem enough to know whether there are any other tools or things that should be installed or options that should be given. For instance, should https://flutter.dev/  be a separate feature that depends on Dart or rolled into the same one? Probably separate, but I'm not in-tune enough to know 100%.

Nevertheless I think that merging this basic Dart feature would be good to get https://github.com/devcontainers-community/templates/pull/31 flying even if #17 is not finished yet.