### PR TITLE
feat(cmake): add CMake feature

### DIFF
--- a/src/cmake/NOTES.md
+++ b/src/cmake/NOTES.md
@@ -1,0 +1,29 @@
+<!-- markdownlint-disable MD041 MD033 -->
+
+<div align="center">
+
+[![CMake website](https://thum.io/get/width/800/crop/600/noanimate/https://cmake.org/)](https://cmake.org/)
+
+</div>
+
+> CMake is an open-source, cross-platform family of tools designed to build,
+> test and package software. CMake is used to control the software compilation
+> process using simple platform and compiler independent configuration files,
+> and generate native makefiles and workspaces that can be used in the compiler
+> environment of your choice. The suite of CMake tools were created by Kitware
+> in response to the need for a powerful, cross-platform build environment for
+> open-source projects such as ITK and VTK.
+
+&mdash; [CMake]
+
+This feature installs the `cmake` binary and tools globally. This is useful if
+your project uses C/C++ tooling.
+
+🆘 If you're having trouble with this feature, [open a Discussion] or [open an
+Issue]! We'd be happy to fix bugs! 🐛
+
+<!-- prettier-ignore-start -->
+[CMake]: https://cmake.org/
+[open a Discussion]: https://github.com/devcontainers-community/features/discussions/new?category=q-a
+[open an Issue]: https://github.com/devcontainers-community/features/issues/new
+<!-- prettier-ignore-end -->

--- a/src/cmake/_common.sh
+++ b/src/cmake/_common.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+clear_local_apt_index() (
+  set -e
+
+  rm -rf /var/lib/apt/lists/*
+  echo '🟩 Cleared local apt index'
+)
+
+ensure_apt_packages() (
+  set -e
+
+  export DEBIAN_FRONTEND=noninteractive
+  if dpkg -s "$@" &>/dev/null; then
+    echo "🟦 $@ is already installed"
+  else
+    if [[ $(find /var/lib/apt/lists/* | wc -l) == 0 ]]; then
+      echo '🟪 Updating local apt index...'
+      apt-get update -y
+      echo '🟩 Updated local apt index'
+    fi
+    echo "🟪 Installing $@..."
+    apt-get install -y --no-install-recommends "$@"
+    echo "🟩 Installed $@"
+  fi
+)

--- a/src/cmake/devcontainer-feature.json
+++ b/src/cmake/devcontainer-feature.json
@@ -1,0 +1,23 @@
+{
+  "id": "cmake",
+  "name": "CMake",
+  "description": "Installs CMake and optionally Ninja and build-essential",
+  "version": "1.0.0",
+  "options": {
+    "version": {
+      "description": "CMake version",
+      "type": "string",
+      "default": "latest"
+    },
+    "installNinja": {
+      "description": "Install Ninja build system",
+      "type": "boolean",
+      "default": true
+    },
+    "installBuildEssential": {
+      "description": "Install build-essential",
+      "type": "boolean",
+      "default": true
+    }
+  }
+}

--- a/src/cmake/install.sh
+++ b/src/cmake/install.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+source _common.sh
+
+ensure_apt_packages curl ca-certificates jq
+
+if [[ -z $VERSION || $VERSION == latest ]]; then
+  echo "🟪 Fetching latest CMake release..."
+  curl -fsSLo latest-release.json https://api.github.com/repos/Kitware/CMake/releases/latest
+  version=$(jq -r .tag_name latest-release.json | sed 's/^v//')
+  echo "🟦 Using latest CMake release: v$version"
+else
+  version="$VERSION"
+  echo "🟦 Using CMake release: v$version"
+fi
+
+echo "🟪 Installing CMake v$version..."
+curl -fsSLo cmake.sh "https://github.com/Kitware/CMake/releases/download/v$version/cmake-$version-linux-x86_64.sh"
+chmod +x cmake.sh
+./cmake.sh --skip-license --prefix=/usr/local
+echo "🟩 Installed CMake v$version"
+
+if [[ $INSTALLBUILDESSENTIAL == true ]]; then
+  echo "🟪 Installing build-essential..."
+  ensure_apt_packages build-essential
+  echo "🟩 Installed build-essential"
+fi
+
+if [[ $INSTALLNINJA == true ]]; then
+  echo "🟪 Installing Ninja..."
+  ensure_apt_packages ninja-build
+  echo "🟩 Installed Ninja"
+fi
+
+clear_local_apt_index


### PR DESCRIPTION
Right now it uses the default installer script from https://cmake.org/download/

![image](https://github.com/devcontainers-community/features/assets/61068799/15606630-538a-40f9-a021-2cafef5f8135)

Need to add the aarch64 support