### PR TITLE
ci(docs): update website automatically after releasing

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,13 +1,6 @@
 name: Deploy docs
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - docs/**
-      - src/**
-      - .github/workflows/preview-docs.yml
   pull_request:
     paths:
       - docs/**

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,6 +13,7 @@ on:
       - docs/**
       - src/**
       - .github/workflows/preview-docs.yml
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,25 +26,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create PR for Documentation
-        id: push_image_info
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -e
-          echo "Start."
-          # Configure git and Push updates
-          git config --global user.email github-actions@github.com
-          git config --global user.name github-actions
-          git config pull.rebase false
-          branch="automated-documentation-update-${GITHUB_RUN_ID}"
-          git checkout -b "${branch}"
-          message='Automated documentation update'
-          # Add / update and commit
-          git add "*/**/README.md"
-          git commit -m 'Automated documentation update [skip ci]' || export NO_UPDATES=true
-          # Push
-          if [ "$NO_UPDATES" != "true" ] ; then
-              git push origin "${branch}"
-              gh pr create --title "$message" --body "$message"
-          fi
+      - name: Update document
+        uses: ./github/workflows/deploy-docs.yml


### PR DESCRIPTION
Close #31

Thinking about the release workflow, we need to deploy after the release workflow has run, not when we push to the main branch.